### PR TITLE
Support automatic installation on apt-get based distros 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ arch_install() {
     local cmd=$1
     local package=$2
 
-    if test "$(command -v $cmd)" == 0; then
+    if command -v $cmd &>/dev/null; then
         echo "Installing $package"
         sudo pacman -S $package
     else
@@ -16,7 +16,7 @@ apt-get_install() {
     local cmd=$1
     local package=$2
 
-    if test "$(command -v $cmd)" == 0; then
+    if command -v $cmd &>/dev/null; then
         echo "Installing $package"
         sudo apt-get install $package
     else
@@ -30,11 +30,11 @@ pip_install() {
 }
 
 # install required programs
-if test "$(command -v apt-get)" == 0; then
+if command -v apt-get &>/dev/null; then
     # install packages for apt-get based systems
     apt-get_install python3 python3
     apt-get_install pip python-pip
-elif test "$(command -v pacman)" == 0; then
+elif command -v pacman &>/dev/null; then
     # install packages for pacman based systems
     arch_install python3 python
     arch_install pip python-pip

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-#
-# NOTE: this script only works with the Arch Linux package manager
 
 arch_install() {
     local cmd=$1
@@ -32,8 +30,23 @@ pip_install() {
 }
 
 # install required programs
-arch_install python3 python
-arch_install pip python-pip
+if test "$(command -v apt-get)" == 0; then
+    # install packages for apt-get based systems
+    apt-get_install python3 python3
+    apt-get_install pip python-pip
+elif test "$(command -v pacman)" == 0; then
+    # install packages for pacman based systems
+    arch_install python3 python
+    arch_install pip python-pip
+else
+    echo "Sorry, we do not support automatic pacakge installion for your package manager"
+    read -p "Do you want to continue anyway? " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
+        exit 1
+    fi
+fi
+# install required Python modules
 pip_install requests
 
 # symlink the executable for the systemd service so that it can easily be found

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,18 @@ arch_install() {
     fi
 }
 
+apt-get_install() {
+    local cmd=$1
+    local package=$2
+
+    if test "$(command -v $cmd)" == 0; then
+        echo "Installing $package"
+        sudo apt-get install $package
+    else
+        echo "$cmd already installed"
+    fi
+}
+
 pip_install() {
     local pypi_package=$1
     sudo pip install $pypi_package


### PR DESCRIPTION
Automatically installing on apt-get based distributions is now supported.

The install script uses the installed package manager to determine which type of distro the system is. It assumes that only one package manager is used, so if there are more than one installed, then the behavior is unknown.
